### PR TITLE
Fix UDP Port sticking

### DIFF
--- a/Server/Resources/Scripts/net/SRCServer/SRCMissionExport.lua
+++ b/Server/Resources/Scripts/net/SRCServer/SRCMissionExport.lua
@@ -8,6 +8,7 @@ local logger = SRCLogger:new("SRCMissionExport.lua")
 logger:info("Mission Export Done", "Loading...")
 
 local udpSendSocket = socket.udp()
+udpSendSocket:settimeout(0)
 
 local function sideEnumToString(side)
     if side == 0 then


### PR DESCRIPTION
This may be a Steam Edition issue? For some reason, the UDP port never fully lets go if there is an interruption of the SRC Server.